### PR TITLE
Feature/3012-Dynamic-Access-Control-Headers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,3 +5,4 @@ RUN sed -i 's/{{port}}/8080/g' /etc/nginx/nginx.conf
 RUN sed -i 's/$host/$host:8080/g' /etc/nginx/nginx.conf
 RUN sed -i 's/{{nameservers}}/127.0.0.11/g' /etc/nginx/nginx.conf
 RUN sed -i 's/{{env "FECFILE_WEB_API"}}/http:\/\/api:8080/g' /etc/nginx/nginx.conf
+RUN sed -i 's/{{env "FECFILE_WEB_CLIENT"}}/http:\/\/localhost:4200/g' /etc/nginx/nginx.conf

--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -11,3 +11,4 @@ applications:
       - nginx_buildpack
     env:
       FECFILE_WEB_API: "http://fecfile-web-api-dev.apps.internal:8080"
+      FECFILE_WEB_CLIENT: "https://dev.fecfile.fec.gov"

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -11,3 +11,4 @@ applications:
       - nginx_buildpack
     env:
       FECFILE_WEB_API: "http://fecfile-web-api-prod.apps.internal:8080"
+      FECFILE_WEB_CLIENT: "https://fecfile.fec.gov"

--- a/manifest_stage.yml
+++ b/manifest_stage.yml
@@ -11,3 +11,4 @@ applications:
       - nginx_buildpack
     env:
       FECFILE_WEB_API: "http://fecfile-web-api-stage.apps.internal:8080"
+      FECFILE_WEB_CLIENT: "https://stage.fecfile.fec.gov"

--- a/manifest_test.yml
+++ b/manifest_test.yml
@@ -11,3 +11,4 @@ applications:
       - nginx_buildpack
     env:
       FECFILE_WEB_API: "http://fecfile-web-api-test.apps.internal:8080"
+      FECFILE_WEB_CLIENT: "https://test.fecfile.fec.gov"

--- a/nginx.conf
+++ b/nginx.conf
@@ -38,9 +38,6 @@ http {
     client_max_body_size 300K;
 
     location / {
-      if ($request_method = OPTIONS) {
-        return 200;
-      }
       resolver {{nameservers}} ipv6=off valid=1s;
       set $backend "{{env "FECFILE_WEB_API"}}";
       set $client "{{env "FECFILE_WEB_CLIENT"}}";
@@ -53,6 +50,9 @@ http {
       add_header Access-Control-Allow-Credentials true always;
       add_header Access-Control-Allow-Headers "accept, authorization, content-type, user-agent, x-csrftoken, x-requested-with, enctype, token, cache-control" always;
       add_header Access-Control-Allow-Methods "DELETE, GET, OPTIONS, PATCH, POST, PUT" always;
+      if ($request_method = OPTIONS) {
+        return 200;
+      }
     }
   }
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -43,12 +43,13 @@ http {
       }
       resolver {{nameservers}} ipv6=off valid=1s;
       set $backend "{{env "FECFILE_WEB_API"}}";
+      set $client "{{env "FECFILE_WEB_CLIENT"}}";
       proxy_pass $backend;
       proxy_set_header X-Forwarded-Proto https;
       proxy_set_header X-Forwarded-Host $host;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       #proxy_set_header X-Script-Name "/";
-      add_header Access-Control-Allow-Origin https://dev.fecfile.fec.gov always;
+      add_header Access-Control-Allow-Origin $client always;
       add_header Access-Control-Allow-Credentials true always;
       add_header Access-Control-Allow-Headers "accept, authorization, content-type, user-agent, x-csrftoken, x-requested-with, enctype, token, cache-control" always;
       add_header Access-Control-Allow-Methods "DELETE, GET, OPTIONS, PATCH, POST, PUT" always;

--- a/nginx.conf
+++ b/nginx.conf
@@ -46,7 +46,7 @@ http {
       proxy_set_header X-Forwarded-Host $host;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       #proxy_set_header X-Script-Name "/";
-      add_header Access-Control-Allow-Origin $client always;
+      add_header Access-Control-Allow-Origin "http://localhost:4200" always;
       add_header Access-Control-Allow-Credentials true always;
       add_header Access-Control-Allow-Headers "accept, authorization, content-type, user-agent, x-csrftoken, x-requested-with, enctype, token, cache-control" always;
       add_header Access-Control-Allow-Methods "DELETE, GET, OPTIONS, PATCH, POST, PUT" always;

--- a/nginx.conf
+++ b/nginx.conf
@@ -46,7 +46,7 @@ http {
       proxy_set_header X-Forwarded-Host $host;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       #proxy_set_header X-Script-Name "/";
-      add_header Access-Control-Allow-Origin "http://localhost:4200" always;
+      add_header Access-Control-Allow-Origin $client always;
       add_header Access-Control-Allow-Credentials true always;
       add_header Access-Control-Allow-Headers "accept, authorization, content-type, user-agent, x-csrftoken, x-requested-with, enctype, token, cache-control" always;
       add_header Access-Control-Allow-Methods "DELETE, GET, OPTIONS, PATCH, POST, PUT" always;

--- a/nginx.conf
+++ b/nginx.conf
@@ -38,6 +38,9 @@ http {
     client_max_body_size 300K;
 
     location / {
+      if ($request_method = OPTIONS) {
+        return 200;
+      }
       resolver {{nameservers}} ipv6=off valid=1s;
       set $backend "{{env "FECFILE_WEB_API"}}";
       set $client "{{env "FECFILE_WEB_CLIENT"}}";
@@ -50,9 +53,6 @@ http {
       add_header Access-Control-Allow-Credentials true always;
       add_header Access-Control-Allow-Headers "accept, authorization, content-type, user-agent, x-csrftoken, x-requested-with, enctype, token, cache-control" always;
       add_header Access-Control-Allow-Methods "DELETE, GET, OPTIONS, PATCH, POST, PUT" always;
-      if ($request_method = OPTIONS) {
-        return 200;
-      }
     }
   }
 }


### PR DESCRIPTION
Sets the access control allow origin header using an environment variable so that each environment's nginx.conf points to the _correct_ client

Ticket link: https://fecgov.atlassian.net/browse/FECFILE-3012
  
Related PRs: [API](https://github.com/fecgov/fecfile-web-api/pull/2023), [Proxy](https://github.com/fecgov/fecfile-api-proxy/pull/49)