### PR TITLE
FOSEC-108: Update Dockerfile to remove copying blockips.conf over.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM nginx:stable
-COPY nginx.conf mime.types blockips.conf /etc/nginx/
+COPY nginx.conf mime.types /etc/nginx/
 RUN sed -i '/daemon off;/d' /etc/nginx/nginx.conf
 RUN sed -i 's/{{port}}/8080/g' /etc/nginx/nginx.conf
 RUN sed -i 's/$host/$host:8080/g' /etc/nginx/nginx.conf


### PR DESCRIPTION
Ticket:
https://fecgov.atlassian.net/browse/FOSEC-108

Related:
https://github.com/fecgov/fecfile-api-proxy/pull/54 (preceded by)
https://github.com/fecgov/fecfile-api-proxy/pull/55 (preceded by)