### PR TITLE
FOSEC-108: Include a placeholder/example blockips.conf for builds outside circle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM nginx:stable
-COPY nginx.conf mime.types /etc/nginx/
+COPY nginx.conf mime.types blockips.conf /etc/nginx/
 RUN sed -i '/daemon off;/d' /etc/nginx/nginx.conf
 RUN sed -i 's/{{port}}/8080/g' /etc/nginx/nginx.conf
 RUN sed -i 's/$host/$host:8080/g' /etc/nginx/nginx.conf

--- a/blockips.conf
+++ b/blockips.conf
@@ -1,0 +1,5 @@
+# The entire if condition is needed to block an IP
+
+# if ($http_x_forwarded_for ~* "(^|,\s*)x\.x\.x\.x(\s*,|$)") {
+#    return 403;
+# }


### PR DESCRIPTION
Ticket:
https://fecgov.atlassian.net/browse/FOSEC-108

Related:
https://github.com/fecgov/fecfile-api-proxy/pull/54 (preceded by)
https://github.com/fecgov/fecfile-api-proxy/pull/55 (preceded by)
https://github.com/fecgov/fecfile-api-proxy/pull/56 (preceded by)